### PR TITLE
feat: add constructors as identifiers

### DIFF
--- a/etc/ioc-deco.api.md
+++ b/etc/ioc-deco.api.md
@@ -10,7 +10,7 @@ type AsyncContainerModule = (bind: BindFunction, unbind: UnbindFunction, isBound
 // @public (undocumented)
 interface Binder<in out T> {
     // (undocumented)
-    to: (fn: new () => T) => void;
+    to: (fn: Constructor<T>) => void;
     // (undocumented)
     toConstantValue: ((v: T) => void) & ((v: Promise<T>) => Promise<void>);
     // (undocumented)
@@ -18,10 +18,13 @@ interface Binder<in out T> {
 }
 
 // @public (undocumented)
-type BindFunction = <T>(token: Token<T>) => BindingBuilder<T>;
+type BindFunction = {
+    <T>(id: Constructor<T>): ClassBindingBuilder<T>;
+    <T>(id: ServiceIdentifier<T>): BindingBuilder<T>;
+};
 
 // @public (undocumented)
-interface BindingBuilder<in out T> extends Binder<T>, BindingScope<T, BindingBuilder<T>> {
+interface BindingBuilder<in out T> extends Binder<T>, BindingScope<T, BindingBuilder<T>>, ClassBinder<T> {
 }
 
 // @public (undocumented)
@@ -29,7 +32,7 @@ interface BindingContext<out T> {
     // (undocumented)
     container: Container;
     // (undocumented)
-    token: Token<T>;
+    id: ServiceIdentifier<T>;
 }
 
 // @public (undocumented)
@@ -43,11 +46,26 @@ interface BindingScope<in T, out Builder> {
 }
 
 // @public (undocumented)
+interface ClassBinder<in T> {
+    // (undocumented)
+    toSelf: () => void;
+}
+
+// @public (undocumented)
+interface ClassBindingBuilder<in out T> extends Binder<T>, BindingScope<T, BindingBuilder<T>>, ClassBinder<T> {
+}
+
+// Warning: (ae-missing-release-tag) "Constructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+type Constructor<T> = new () => T;
+
+// @public (undocumented)
 interface Container {
     // (undocumented)
     bind: BindFunction;
     // (undocumented)
-    get: <T>(token: Token<T>) => Promise<T>;
+    get: <T>(id: ServiceIdentifier<T>) => Promise<T>;
     // (undocumented)
     has: IsBoundFunction;
     // (undocumented)
@@ -127,8 +145,11 @@ declare namespace interfaces {
         Binder,
         FixedScopeBindingOptions,
         BindingBuilder,
+        ClassBindingBuilder,
         BindingContext,
         BindingScope,
+        ClassBinder,
+        Constructor,
         Container,
         ContainerConfiguration,
         AsyncContainerModule,
@@ -139,19 +160,25 @@ declare namespace interfaces {
         RebindFunction,
         UnbindFunction,
         InjectOptions,
-        ScopeOptions
+        ScopeOptions,
+        ServiceIdentifier
     }
 }
 export { interfaces }
 
 // @public (undocumented)
-type IsBoundFunction = (token: Token<unknown>) => boolean;
+type IsBoundFunction = <T>(id: ServiceIdentifier<T>) => boolean;
 
 // @public (undocumented)
-type RebindFunction = <T>(token: Token<T>) => BindingBuilder<T>;
+type RebindFunction = BindFunction;
 
 // @public (undocumented)
 type ScopeOptions = 'transient' | 'request' | 'singleton';
+
+// Warning: (ae-missing-release-tag) "ServiceIdentifier" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+type ServiceIdentifier<T> = (new () => T) | Token<T>;
 
 // @public (undocumented)
 type SyncContainerModule = (bind: BindFunction, unbind: UnbindFunction, isBound: IsBoundFunction, rebind: RebindFunction) => void;
@@ -167,7 +194,7 @@ export class Token<out T> {
 export type TokenType<T extends Token<unknown>> = T extends Token<infer U> ? U : never;
 
 // @public (undocumented)
-type UnbindFunction = (token: Token<unknown>) => void;
+type UnbindFunction = <T>(id: ServiceIdentifier<T>) => void;
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/Bindings.ts
+++ b/src/__tests__/Bindings.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import { describe, expect, it, jest } from '@jest/globals';
 import { Container } from '../Container.js';
+import { injectable } from '../decorators/injectable.js';
 import { Token } from '../Token.js';
 import type { TokenType } from '../Token.js';
 
@@ -202,6 +203,20 @@ describe('Bindings', () => {
 			await c.load(async () => {
 				/* no op */
 			});
+		});
+	});
+
+	describe('Constructor service identifier', () => {
+		it('can use a class as a service identifier', async () => {
+			const c = new Container();
+			@injectable()
+			class Test {
+				public id = 10;
+			}
+
+			c.bind(Test).toSelf();
+
+			await expect(c.get(Test)).resolves.toMatchObject({ id: 10 });
 		});
 	});
 });

--- a/src/interfaces/.eslintrc
+++ b/src/interfaces/.eslintrc
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"@typescript-eslint/no-type-alias": "off"
+	}
+}

--- a/src/interfaces/Binder.ts
+++ b/src/interfaces/Binder.ts
@@ -1,14 +1,14 @@
 import type { BindingContext } from './BindingContext.js';
+import type { Constructor } from './Constructor.js';
 
 /** @public */
-// eslint-disable-next-line @typescript-eslint/no-type-alias
 export type FixedScopeBindingOptions = 'toConstantValue';
 
 /**
  * @public
  */
 export interface Binder<in out T> {
-	to: (fn: new () => T) => void;
+	to: (fn: Constructor<T>) => void;
 	toConstantValue: ((v: T) => void) & ((v: Promise<T>) => Promise<void>);
 	toDynamicValue: (fn: (context: BindingContext<T>) => T | Promise<T>) => void;
 }

--- a/src/interfaces/BindingBuilder.ts
+++ b/src/interfaces/BindingBuilder.ts
@@ -1,7 +1,13 @@
 import type { Binder } from './Binder.js';
 import type { BindingScope } from './BindingScope.js';
+import type { ClassBinder } from './ClassBinder.js';
 
 /**
  * @public
  */
-export interface BindingBuilder<in out T> extends Binder<T>, BindingScope<T, BindingBuilder<T>> {}
+export interface BindingBuilder<in out T> extends Binder<T>, BindingScope<T, BindingBuilder<T>>, ClassBinder<T> {}
+
+/**
+ * @public
+ */
+export interface ClassBindingBuilder<in out T> extends Binder<T>, BindingScope<T, BindingBuilder<T>>, ClassBinder<T> {}

--- a/src/interfaces/BindingBuilder.ts
+++ b/src/interfaces/BindingBuilder.ts
@@ -10,4 +10,4 @@ export interface BindingBuilder<in out T> extends Binder<T>, BindingScope<T, Bin
 /**
  * @public
  */
-export interface ClassBindingBuilder<in out T> extends Binder<T>, BindingScope<T, BindingBuilder<T>>, ClassBinder<T> {}
+export interface ClassBindingBuilder<in out T> extends BindingBuilder<T>, ClassBinder<T> {}

--- a/src/interfaces/BindingContext.ts
+++ b/src/interfaces/BindingContext.ts
@@ -1,10 +1,10 @@
 import type { Container } from './Container.js';
-import type { Token } from '../Token.js';
+import type { ServiceIdentifier } from './ServiceIdentifier.js';
 
 /**
  * @public
  */
 export interface BindingContext<out T> {
 	container: Container;
-	token: Token<T>;
+	id: ServiceIdentifier<T>;
 }

--- a/src/interfaces/ClassBinder.ts
+++ b/src/interfaces/ClassBinder.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/**
+ * @public
+ */
+export interface ClassBinder<in T> {
+	toSelf: () => void;
+}

--- a/src/interfaces/Constructor.ts
+++ b/src/interfaces/Constructor.ts
@@ -1,0 +1,2 @@
+/** @public */
+export type Constructor<T> = new () => T;

--- a/src/interfaces/Container.ts
+++ b/src/interfaces/Container.ts
@@ -1,6 +1,6 @@
 import type { AsyncContainerModule, SyncContainerModule } from './ContainerModule.js';
 import type { BindFunction, IsBoundFunction, RebindFunction, UnbindFunction } from './Functions.js';
-import type { Token } from '../Token.js';
+import type { ServiceIdentifier } from './ServiceIdentifier.js';
 
 /**
  * @public
@@ -14,5 +14,5 @@ export interface Container {
 		(module: AsyncContainerModule): Promise<void>;
 		(module: SyncContainerModule): void;
 	};
-	get: <T>(token: Token<T>) => Promise<T>;
+	get: <T>(id: ServiceIdentifier<T>) => Promise<T>;
 }

--- a/src/interfaces/Functions.ts
+++ b/src/interfaces/Functions.ts
@@ -1,11 +1,15 @@
-import type { BindingBuilder } from './BindingBuilder.js';
-import type { Token } from '../Token.js';
+import type { BindingBuilder, ClassBindingBuilder } from './BindingBuilder.js';
+import type { Constructor } from './Constructor.js';
+import type { ServiceIdentifier } from './ServiceIdentifier.js';
 
 /** @public */
-export type BindFunction = <T>(token: Token<T>) => BindingBuilder<T>;
+export type BindFunction = {
+	<T>(id: Constructor<T>): ClassBindingBuilder<T>;
+	<T>(id: ServiceIdentifier<T>): BindingBuilder<T>;
+};
 /** @public */
-export type IsBoundFunction = (token: Token<unknown>) => boolean;
+export type IsBoundFunction = <T>(id: ServiceIdentifier<T>) => boolean;
 /** @public */
-export type RebindFunction = <T>(token: Token<T>) => BindingBuilder<T>;
+export type RebindFunction = BindFunction;
 /** @public */
-export type UnbindFunction = (token: Token<unknown>) => void;
+export type UnbindFunction = <T>(id: ServiceIdentifier<T>) => void;

--- a/src/interfaces/ServiceIdentifier.ts
+++ b/src/interfaces/ServiceIdentifier.ts
@@ -1,0 +1,4 @@
+import type { Token } from '../Token.js';
+
+/** @public */
+export type ServiceIdentifier<T> = (new () => T) | Token<T>;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,10 +1,13 @@
 export type { Binder, FixedScopeBindingOptions } from './Binder.js';
-export type { BindingBuilder } from './BindingBuilder.js';
+export type { BindingBuilder, ClassBindingBuilder } from './BindingBuilder.js';
 export type { BindingContext } from './BindingContext.js';
 export type { BindingScope } from './BindingScope.js';
+export type { ClassBinder } from './ClassBinder.js';
+export type { Constructor } from './Constructor.js';
 export type { Container } from './Container.js';
 export type { ContainerConfiguration } from './ContainerConfiguration.js';
 export type { AsyncContainerModule, ContainerModule, SyncContainerModule } from './ContainerModule.js';
 export type { BindFunction, IsBoundFunction, RebindFunction, UnbindFunction } from './Functions.js';
 export type { InjectOptions } from './InjectOptions.js';
 export type { ScopeOptions } from './ScopeOptions.js';
+export type { ServiceIdentifier } from './ServiceIdentifier.js';

--- a/src/models/.eslintrc
+++ b/src/models/.eslintrc
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"@typescript-eslint/no-type-alias": "off"
+	}
+}

--- a/src/models/Binding.ts
+++ b/src/models/Binding.ts
@@ -1,9 +1,9 @@
-/* eslint-disable @typescript-eslint/no-type-alias */
 import type * as interfaces from '../interfaces/index.js';
 import type { Token } from '../Token.js';
 
 export interface ConstructorBinding<out T> {
 	type: 'constructor';
+	id: interfaces.ServiceIdentifier<T>;
 	token: Token<T>;
 	scope: interfaces.ScopeOptions;
 	ctr: new () => T;
@@ -11,6 +11,7 @@ export interface ConstructorBinding<out T> {
 
 export interface StaticBinding<out T> {
 	type: 'static';
+	id: interfaces.ServiceIdentifier<T>;
 	token: Token<T>;
 	scope: interfaces.ScopeOptions;
 	value: T;
@@ -18,6 +19,7 @@ export interface StaticBinding<out T> {
 
 export interface DynamicBinding<in out T> {
 	type: 'dynamic';
+	id: interfaces.ServiceIdentifier<T>;
 	token: Token<T>;
 	scope: interfaces.ScopeOptions;
 	generator: (context: interfaces.BindingContext<T>) => T | Promise<T>;

--- a/src/models/Injection.ts
+++ b/src/models/Injection.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-type-alias */
 import type * as interfaces from '../interfaces/index.js';
 import type { Token } from '../Token.js';
 

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-type-alias */
-
 import type { Token } from '../Token.js';
 
 export interface FetchFromCache<T = unknown> {

--- a/src/util/stringifyIdentifier.ts
+++ b/src/util/stringifyIdentifier.ts
@@ -1,0 +1,10 @@
+import type * as interfaces from '../interfaces/index.js';
+import { Token } from '../Token.js';
+
+export const stringifyIdentifier = <T>(id: interfaces.ServiceIdentifier<T>): string => {
+	if (id instanceof Token) {
+		return `Token<${id.identifier.toString()}>`;
+	} else {
+		return `Constructor<${id.name}>`;
+	}
+};

--- a/src/util/tokenForIdentifier.ts
+++ b/src/util/tokenForIdentifier.ts
@@ -1,0 +1,16 @@
+import type * as interfaces from '../interfaces/index.js';
+import { Token } from '../Token.js';
+
+const _mappings = new WeakMap<interfaces.Constructor<unknown>, Token<unknown>>();
+
+export const tokenForIdentifier = <T>(id: interfaces.ServiceIdentifier<T>): Token<T> => {
+	if (id instanceof Token) {
+		return id;
+	} else {
+		if (!_mappings.has(id)) {
+			_mappings.set(id, new Token(id.name));
+		}
+
+		return _mappings.get(id) as Token<T>;
+	}
+};


### PR DESCRIPTION
Fixes #34 

Adds the ability use constructors directly as identifiers for binding and injections.