### PR TITLE
fix: add a warning log for dynamic bindings that aren't scoped

### DIFF
--- a/src/__tests__/Bindings.ts
+++ b/src/__tests__/Bindings.ts
@@ -39,10 +39,12 @@ describe('Bindings', () => {
 	describe('isProcessingRequest', () => {
 		it('can display if a request is running', async () => {
 			const c = new Container();
-			c.bind(token).toDynamicValue(() => {
-				expect(Container.isProcessingRequest).toBe(true);
-				return { id: 10 };
-			});
+			c.bind(token)
+				.inTransientScope()
+				.toDynamicValue(() => {
+					expect(Container.isProcessingRequest).toBe(true);
+					return { id: 10 };
+				});
 			await expect(c.get(token)).resolves.toMatchObject({ id: 10 });
 		});
 

--- a/src/__tests__/CircularDependencies.ts
+++ b/src/__tests__/CircularDependencies.ts
@@ -35,14 +35,18 @@ describe('CircularDependencies', () => {
 	it('throws an error for recursion across dynamic bindings', async () => {
 		const c = new Container();
 
-		c.bind(t1).toDynamicValue(async ({ container }) => {
-			const { name } = await container.get(t2);
-			return { id: 0, name };
-		});
-		c.bind(t2).toDynamicValue(async ({ container }) => {
-			const { id } = await container.get(t1);
-			return { id, name: 'world' };
-		});
+		c.bind(t1)
+			.inTransientScope()
+			.toDynamicValue(async ({ container }) => {
+				const { name } = await container.get(t2);
+				return { id: 0, name };
+			});
+		c.bind(t2)
+			.inTransientScope()
+			.toDynamicValue(async ({ container }) => {
+				const { id } = await container.get(t1);
+				return { id, name: 'world' };
+			});
 
 		await expect(c.get(t1)).rejects.toMatchObject({
 			cause: {

--- a/src/__tests__/ExceptionHandling.ts
+++ b/src/__tests__/ExceptionHandling.ts
@@ -1,4 +1,6 @@
+/* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
+
 import { createContainer, injectable, Token } from '../index.js';
 import { describe, expect, it } from '@jest/globals';
 
@@ -27,9 +29,11 @@ describe('ExceptionHandling', () => {
 
 		it('dynamic value', async () => {
 			const c = createContainer();
-			c.bind(token).toDynamicValue(() => {
-				throw new Error('Oops, something bad happened.');
-			});
+			c.bind(token)
+				.inTransientScope()
+				.toDynamicValue(() => {
+					throw new Error('Oops, something bad happened.');
+				});
 
 			await expect(c.get(token)).rejects.toMatchObject({
 				cause: {
@@ -41,10 +45,12 @@ describe('ExceptionHandling', () => {
 
 		it('async dynamic value', async () => {
 			const c = createContainer();
-			// eslint-disable-next-line @typescript-eslint/require-await
-			c.bind(token).toDynamicValue(async () => {
-				throw new Error('Oops, something bad happened.');
-			});
+
+			c.bind(token)
+				.inTransientScope()
+				.toDynamicValue(async () => {
+					throw new Error('Oops, something bad happened.');
+				});
 
 			await expect(c.get(token)).rejects.toMatchObject({
 				cause: {
@@ -80,7 +86,9 @@ describe('ExceptionHandling', () => {
 			const greeterToken = new Token<Greeter>('greeter');
 
 			c.bind(token).to(Test);
-			c.bind(nameToken).toDynamicValue(async (ctx) => `dummy-${(await ctx.container.get(token)).id}`);
+			c.bind(nameToken)
+				.inTransientScope()
+				.toDynamicValue(async (ctx) => `dummy-${(await ctx.container.get(token)).id}`);
 			c.bind(greeterToken).to(Greeter);
 
 			await expect(c.get(greeterToken)).rejects.toMatchObject({

--- a/src/__tests__/NestedRequests.ts
+++ b/src/__tests__/NestedRequests.ts
@@ -19,7 +19,10 @@ describe('Nested requests', () => {
 	it('can handle nested requests without loosing track', async () => {
 		const container = new Container();
 		container.bind(numberToken).toConstantValue(10);
-		container.bind(stringToken).toDynamicValue(async ({ container: c }) => (await c.get(numberToken)).toFixed(2));
+		container
+			.bind(stringToken)
+			.inTransientScope()
+			.toDynamicValue(async ({ container: c }) => (await c.get(numberToken)).toFixed(2));
 		container.bind(classToken).to(TestClass);
 
 		await expect(container.get(classToken)).resolves.toMatchObject({ test: '10.00' });


### PR DESCRIPTION
Fixes #77 